### PR TITLE
:iphone: Add Python 3.11 support

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     defaults:
       run:
         shell: bash -l {0}

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ projects. Watch this space.
 ## Installation
 
 The package requires no dependencies and is currently available for Pythons 
-2.7, 3.7, 3.8, 3.9 and 3.10.
+3.8, 3.9, 3.10 and 3.11.
 
 The latest stable version of the package can be downloaded from PyPI using 
 [pip](https://packaging.python.org/tutorials/installing-packages/):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,13 +16,11 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Natural Language :: English",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 2",
-    "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Scientific/Engineering"
 ]
 

--- a/src/convergence/interface.py
+++ b/src/convergence/interface.py
@@ -149,7 +149,7 @@ class Convergence(object):
                                          ratio_21,
                                          ratio_32)
             except (ArithmeticError, RuntimeError) as e:
-                warnings.warn(e)
+                warnings.warn(str(e))
             
             # Make a dictionary
             shared_dict = {'ratio_21' : ratio_21, 'ratio_32' : ratio_32,
@@ -203,7 +203,7 @@ class Convergence(object):
                                                   trip[1][2],
                                                   float(self._f_anal))
                 except ArithmeticError as e:
-                    warnings.warn(e)
+                    warnings.warn(str(e))
                 
                 # Add these to the dictionary
                 anal_dict = {'f_anal': float(self._f_anal), 
@@ -260,7 +260,7 @@ class Convergence(object):
                                                   trip[2][2],
                                                   float(self._f_anal))
                 except ArithmeticError as e:
-                    warnings.warn(e)
+                    warnings.warn(str(e))
                 
                 # Add these to the dictionary
                 anal_dict = {'f_anal': float(self._f_anal), 
@@ -290,7 +290,7 @@ class Convergence(object):
                                              ratio,
                                              p)
         except ArithmeticError as e:
-            warnings.warn(e)
+            warnings.warn(str(e))
             return f_exact, e21a, e21ext, gci_f, gci_c
         
         # Get the approximate and extrapolated relative errors
@@ -299,14 +299,14 @@ class Convergence(object):
                                            grid_two[2],
                                            f_exact)
         except ArithmeticError as e:
-            warnings.warn(e)
+            warnings.warn(str(e))
             return f_exact, e21a, e21ext, gci_f, gci_c
         
         # Get the gcis
         try:
             gci_f, gci_c = gci(ratio, e21a, p)
         except ArithmeticError as e:
-            warnings.warn(e)
+            warnings.warn(str(e))
         
         return f_exact, e21a, e21ext, gci_f, gci_c
     
@@ -346,7 +346,7 @@ class Convergence(object):
                                              gci_fine_32,
                                              ratio_21, p)
                 except ArithmeticError as e:
-                    warnings.warn(e)
+                    warnings.warn(str(e))
             
             else:
                 

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,11 @@
 [tox]
+isolated_build = true
 requires = tox-conda
 envlist =
-    {py27,py37,py38,py39,py310}
+    {py38,py39,py310,py311}
 
 [testenv]
-setenv=
-    py27: PYTHONIOENCODING = UTF-8
 conda_deps=
-    py27: mock
     pytest
     pytest-mock
 commands=


### PR DESCRIPTION
This PR adds support for Python 3.11, drops mentions of Python 2.7 and 3.7 and fixes a bug where the errors were passed to warnings without being converted to strings.