### PR TITLE
:bug: Fix get_resolution using coarse GCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ pass `"coarse"` as the second optional argument:
 
 ```python
 >>> convergence.get_resolution(0.001, "coarse")
-0.49157306062118994
+0.9831461212423799
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ downloading the source code, and using the command prompt as follows:
 
 ```
 cd /path/to/convergence
-python setup.py install
+pip install --editable .
 ```
 
 Note that the stable version may not contain all of the features found in the

--- a/src/convergence/interface.py
+++ b/src/convergence/interface.py
@@ -603,14 +603,16 @@ class Convergence(object):
         
         if estimate == "fine":
             gci12 = self[0].fine.gci_fine
+            h1 = self._grids[0][0]
         elif estimate == "coarse":
             gci12 = self[0].fine.gci_coarse
+            h1 = self._grids[1][0]
         else:
             raise ValueError("Unrecognised value passed to estimate. Should "
                              "be one of 'fine' or 'coarse'")
         
         p = self[0].coarse.p
-        h1 = self._grids[0][0]
+        
         
         return required_resolution(gci, gci12, p, h1)
         

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -187,7 +187,7 @@ def test_convergence_anal_str(convergence_anal):
 
 @pytest.mark.parametrize("estimate, expected", [
                             ("fine", 0.9831461212423797),
-                            ("coarse", 0.49157306062118994)])
+                            ("coarse", 0.9831461212423799)])
 def test_get_resolution(convergence, estimate, expected):
     assert convergence.get_resolution(0.001, estimate) == expected
 


### PR DESCRIPTION
When using the coarse GCI to calculate the required resolution using `get_resolution`, $h_1$ was set to the fine grid resolution, rather than the coarse grid.